### PR TITLE
make caching optional

### DIFF
--- a/pytholog/knowledge_base.py
+++ b/pytholog/knowledge_base.py
@@ -10,7 +10,7 @@ from .search_util import *
 
 ## the knowledge base object where we will store the facts and rules
 ## it's a dictionary of dictionaries where main keys are the predicates
-## to speed up searching by looking only into relevant buckets rather than looping over 
+## to speed up searching by looking only into relevant buckets rather than looping over
 ## the whole database
 class KnowledgeBase(object):
     __id = 0
@@ -22,7 +22,7 @@ class KnowledgeBase(object):
         KnowledgeBase.__id += 1
         self.name = name
         self._cache = {}
-    
+
     ## the main function that adds new entries or append existing ones
     ## it creates "facts", "goals" and "terms" buckets for each predicate
     def add_kn(self, kn):
@@ -45,15 +45,15 @@ class KnowledgeBase(object):
                 self.db[i.lh.predicate]["terms"].push(i.terms)
                 #self.db[i.lh.predicate]["goals"] = [g]
                 #self.db[i.lh.predicate]["terms"] = [i.terms]
-            
+
     def __call__(self, args):
         self.add_kn(args)
 
     ## query method will only call rule_query which will call the decorators chain
-    ## it is only to be user intuitive readable method                                      
-    def query(self, expr, cut = False, show_path = False):
-        return rule_query(self, expr, cut, show_path)
-        
+    ## it is only to be user intuitive readable method
+    def query(self, expr, cut = False, show_path = False, cache = True):
+        return rule_query(self, expr, cut, show_path, cache=cache)
+
     def rule_search(self, expr):
         if expr.predicate not in self.db:
             return "Rule does not exist!"
@@ -70,12 +70,12 @@ class KnowledgeBase(object):
 
     def __str__(self):
         return "KnowledgeBase: " + self.name
-        
+
     def clear_cache(self):
         self._cache.clear()
 
     __repr__ = __str__
-    
+
 
 class DeprecationHelper(object):
     def __init__(self, new_target):
@@ -94,4 +94,3 @@ class DeprecationHelper(object):
         return getattr(self.new_target, attr)
 
 knowledge_base = DeprecationHelper(KnowledgeBase)
-    

--- a/test_pytholog.py
+++ b/test_pytholog.py
@@ -23,7 +23,7 @@ def test_dishes():
     answer = {"What": "cookie"}
     query = food_kb.query(pl.Expr("food_flavor(What, sweet)"))
     assert answer in query
-    
+
 def test_friends():
     friends_kb = pl.KnowledgeBase("friends")
     friends_kb([
@@ -46,10 +46,10 @@ def test_friends():
     assert david in friends_kb.query(pl.Expr("to_smoke(Who, P)"))
     dan_reb = [{'Who': 'rebecca', 'P': '0.4'}, {'Who': 'daniel', 'P': 0.024000000000000004}]
     assert all(i in friends_kb.query(pl.Expr("to_have_asthma(Who, P)")) for i in dan_reb)
-    
+
 def test_iris():
     iris_kb = pl.KnowledgeBase("iris")
-    iris_kb(["species(setosa, Truth) :- petal_width(W), Truth is W <= 0.80", 
+    iris_kb(["species(setosa, Truth) :- petal_width(W), Truth is W <= 0.80",
              "species(versicolor, Truth) :- petal_width(W), petal_length(L), Truth is W > 0.80 and L <= 4.95",
              "species(virginica, Truth) :- petal_width(W), petal_length(L), Truth is W > 0.80 and L > 4.95",
              "petal_length(5.1)",
@@ -69,4 +69,34 @@ def test_graph():
 
     query = graph.query(pl.Expr("path(a, e, W)"), cut = True)
     assert [d.get("W") for d in query][0] == 10
-    
+
+
+
+def test_memory_off():
+    class_kb = pl.KnowledgeBase("classmates")
+    class_kb([
+        "person(noor)",
+        "person(melissa)",
+        "person(dmitry)",
+    ])
+
+    # we can confirm that the entries are cached based on the sam erequest
+    assert len(class_kb.query(pl.Expr("person(X)"))) == 3
+    class_kb.add_kn(["person(abdel)"])
+    assert len(class_kb.query(pl.Expr("person(X)"))) == 3
+
+
+    new_class = pl.KnowledgeBase("classmates")
+    new_class([
+        "person(noor)",
+        "person(melissa)"
+    ])
+    assert len(new_class.query(pl.Expr("person(X)"))) == 2
+    new_class.add_kn(["person(abdel)"])
+    assert len(new_class.query(pl.Expr("person(X)"), cache=False)) == 3
+    new_class.add_kn(["person(mohammed)"])
+    assert len(new_class.query(pl.Expr("person(X)"), cache=False)) == 4
+
+    # we set cache=True to test that a new entry but using cache
+    new_class.add_kn(["person(rico)"])
+    assert len(new_class.query(pl.Expr("person(X)"))) == 4


### PR DESCRIPTION
Fixes MNoorFawi/pytholog#12
added caching variable to make caching optional. Unit tests added to test this.

**Motivation**
When adding facts dynamically, I would like to make the same query multiple times.
Making the same query multiple times will only returned the cache results instead of the updated results.

**Solution**
Add marker to allow caching to be optional to the `query` function.

**Unit tests**
create new `KnowledgeBase` and add new entries to highlight the problem.
create new `KnowledgeBase` and add new entries and make the same queries with the `cache` marker set to `False`.